### PR TITLE
refactor(discussionRoom): retrieveJoinedRooms 불필요한 추가 쿼리 제거 및 목록 조회 흐…

### DIFF
--- a/src/main/java/org/example/civilbridge/domain/discussionRoom/api/DiscussionRoomController.java
+++ b/src/main/java/org/example/civilbridge/domain/discussionRoom/api/DiscussionRoomController.java
@@ -71,7 +71,7 @@ public class DiscussionRoomController {
             @Parameter(description = "페이지 크기", example = "15")
             @RequestParam(defaultValue = "15") int size
     ) {
-        DiscussionRoomListRes response = discussionRoomService.retrieveTotalRooms(page, size);
+        DiscussionRoomListRes response = discussionRoomService.retrieveRoomsByPage(page, size);
         
         return ResponseEntity.ok(
                 ApiResponse.success(response, "논의방 목록을 조회했습니다.")

--- a/src/main/java/org/example/civilbridge/domain/discussionRoom/application/DiscussionRoomService.java
+++ b/src/main/java/org/example/civilbridge/domain/discussionRoom/application/DiscussionRoomService.java
@@ -13,7 +13,6 @@ import org.example.civilbridge.domain.discussionRoom.domain.repository.MemberRep
 import org.example.civilbridge.domain.discussionRoom.exception.DiscussionRoomErrorCode;
 import org.example.civilbridge.domain.discussionRoom.infra.cache.DiscussionRoomCacheRepository;
 import org.example.civilbridge.domain.discussionRoom.infra.cache.dto.DiscussionRoomCacheModel;
-import org.example.civilbridge.domain.discussionRoom.infra.cache.dto.DiscussionRoomsPage;
 import org.example.civilbridge.domain.user.domain.model.User;
 import org.example.civilbridge.domain.user.domain.repository.UserRepository;
 import org.example.civilbridge.domain.user.exception.UserErrorCode;
@@ -174,7 +173,7 @@ public class DiscussionRoomService {
      * @return 논의방 목록 및 페이징 정보
      */
     @Transactional(readOnly = true)
-    public DiscussionRoomListRes retrieveTotalRooms(int page, int size) {
+    public DiscussionRoomListRes retrieveRoomsByPage(int page, int size) {
         log.info("전체 논의방 목록 조회 - page: {}, size: {}", page, size);
 
         // 1. DB에서 논의방 목록 조회 (페이징) - DB가 source of truth
@@ -186,22 +185,23 @@ public class DiscussionRoomService {
             return DiscussionRoomListRes.of(List.of(), page, size, 0);
         }
 
-        // 2. 각 방 상세 정보 조회 (N+1 쿼리 방지: 멤버 수 일괄 조회)
+        // 2. 멤버 수 일괄 조회를 위한 방 ID 목록 추출
         List<DiscussionRoom> rooms = roomPage.getContent();
         List<Long> roomIds = rooms.stream()
                 .map(DiscussionRoom::getId)
                 .collect(Collectors.toList());
 
-        // 멤버 수 일괄 조회 (N+1 방지)
+        // 방별 멤버 수 IN절로 한 번에 조회  (N+1 방지)--여기까지 이해함(2026-03-13)
         Map<Long, Integer> memberCountMap = memberRepository.countByRoomIds(roomIds);
 
         List<DiscussionRoomInfo> roomSummaries = rooms.stream()
                 .map(room -> {
-                    // retrieveCachingRoom: 캐시 미스 시 DB 조회 후 캐싱
-                    DiscussionRoomCacheModel cached = cacheRepository.retrieveCachingRoom(room.getId())
-                            .orElseGet(() -> {
+                    DiscussionRoomCacheModel cached = cacheRepository.getCachedRoomOnly(room.getId()) // 캐시 히트 → 캐시에서 반환
+                            .orElseGet(() -> { // 캐시 미스 → 메모리 데이터로 조립 후 캐싱
                                 int currentUsers = memberCountMap.getOrDefault(room.getId(), 0);
-                                return DiscussionRoomCacheModel.fromDomainModel(room, currentUsers);
+                                DiscussionRoomCacheModel model = DiscussionRoomCacheModel.fromDomainModel(room, currentUsers);
+                                cacheRepository.cacheRoomInfo(model);
+                                return model;
                             });
                     return DiscussionRoomInfo.from(cached);
                 })
@@ -231,42 +231,45 @@ public class DiscussionRoomService {
     public DiscussionRoomListRes retrieveJoinedRooms(Long userId, int page, int size) {
         log.info("내가 참여한 논의방 목록 조회 - userId: {}, page: {}, size: {}", userId, page, size);
 
-        // 1. DB에서 사용자가 참여한 방 ID 목록 조회 (페이징) - DB가 source of truth
+        // 1. DB에서 사용자가 참여한 논의방 목록 조회 (페이징) - DB가 source of truth
         Pageable pageable = PageRequest.of(page - 1, size);
-        Page<Long> roomIdPage = memberRepository.findRoomIdsByUserId(userId, pageable);
+        Page<DiscussionRoom> roomPage = memberRepository.findRoomsByUserId(userId, pageable);
 
-        if (roomIdPage.isEmpty()) {
+        if (roomPage.isEmpty()) {
             log.debug("참여한 논의방 없음 - userId: {}", userId);
             return DiscussionRoomListRes.of(List.of(), page, size, 0);
         }
 
-        // 2. 각 방 상세 정보 조회 (N+1 쿼리 방지: 일괄 조회)
-        List<Long> roomIds = roomIdPage.getContent();
-        List<DiscussionRoom> rooms = discussionRoomRepository.findAllByIdIn(roomIds);
+        // 2. 방별 멤버 수 IN절로 한 번에 조회 (N+1 방지)
+        List<DiscussionRoom> rooms = roomPage.getContent();
+        List<Long> roomIds = rooms.stream()
+                .map(DiscussionRoom::getId)
+                .collect(Collectors.toList());
 
-        // 멤버 수 일괄 조회 (N+1 방지)
         Map<Long, Integer> memberCountMap = memberRepository.countByRoomIds(roomIds);
 
         List<DiscussionRoomInfo> roomSummaries = rooms.stream()
                 .map(room -> {
-                    // retrieveCachingRoom: 캐시 미스 시 DB 조회 후 캐싱
-                    DiscussionRoomCacheModel cached = cacheRepository.retrieveCachingRoom(room.getId())
+                    // 캐시 히트 → 캐시에서 반환, 캐시 미스 → 메모리 데이터로 조립 후 캐싱
+                    DiscussionRoomCacheModel cached = cacheRepository.getCachedRoomOnly(room.getId())
                             .orElseGet(() -> {
                                 int currentUsers = memberCountMap.getOrDefault(room.getId(), 0);
-                                return DiscussionRoomCacheModel.fromDomainModel(room, currentUsers);
+                                DiscussionRoomCacheModel model = DiscussionRoomCacheModel.fromDomainModel(room, currentUsers);
+                                cacheRepository.cacheRoomInfo(model);
+                                return model;
                             });
                     return DiscussionRoomInfo.from(cached);
                 })
                 .collect(Collectors.toList());
 
         log.info("내가 참여한 논의방 목록 조회 성공 - userId: {}, 조회된 방: {}개, 전체: {}개",
-                userId, roomSummaries.size(), roomIdPage.getTotalElements());
+                userId, roomSummaries.size(), roomPage.getTotalElements());
 
         return DiscussionRoomListRes.of(
                 roomSummaries,
                 page,
                 size,
-                roomIdPage.getTotalElements()
+                roomPage.getTotalElements()
         );
     }
 

--- a/src/main/java/org/example/civilbridge/domain/discussionRoom/domain/repository/MemberRepository.java
+++ b/src/main/java/org/example/civilbridge/domain/discussionRoom/domain/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package org.example.civilbridge.domain.discussionRoom.domain.repository;
 
+import org.example.civilbridge.domain.discussionRoom.domain.model.DiscussionRoom;
 import org.example.civilbridge.domain.discussionRoom.domain.model.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -44,12 +45,12 @@ public interface MemberRepository {
     int countByRoomId(Long roomId);
 
     /**
-     * 사용자가 참여한 논의방 ID 목록 조회 (페이징, 최신 참여순)
+     * 사용자가 참여한 논의방 목록 조회 (페이징, 최신 참여순)
      * @param userId 사용자 ID
      * @param pageable 페이징 정보
-     * @return 페이징된 논의방 ID 목록
+     * @return 페이징된 논의방 목록
      */
-    Page<Long> findRoomIdsByUserId(Long userId, Pageable pageable);
+    Page<DiscussionRoom> findRoomsByUserId(Long userId, Pageable pageable);
 
     /**
      * 여러 논의방의 멤버 수 일괄 조회 (N+1 쿼리 방지)

--- a/src/main/java/org/example/civilbridge/domain/discussionRoom/infra/cache/DiscussionRoomCacheRepository.java
+++ b/src/main/java/org/example/civilbridge/domain/discussionRoom/infra/cache/DiscussionRoomCacheRepository.java
@@ -105,11 +105,27 @@ public interface DiscussionRoomCacheRepository {
     /**
      * 논의방 정보 조회 (room:{id})
      * 캐시 미스 시 DB에서 조회하여 캐싱 후 반환
-     * 
+     *
      * @param roomId 논의방 ID
      * @return 캐시된 논의방 정보 (없으면 Empty)
      */
     Optional<DiscussionRoomCacheModel> retrieveCachingRoom(Long roomId);
+
+    /**
+     * Redis에서만 논의방 정보 조회 (DB fallback 없음)
+     * 목록 조회처럼 이미 메모리에 데이터가 있는 경우 사용
+     *
+     * @param roomId 논의방 ID
+     * @return 캐시된 논의방 정보 (캐시 미스 시 Empty)
+     */
+    Optional<DiscussionRoomCacheModel> getCachedRoomOnly(Long roomId);
+
+    /**
+     * 논의방 정보를 Redis에 캐싱 (room:{id} Hash만)
+     *
+     * @param model 캐싱할 논의방 모델
+     */
+    void cacheRoomInfo(DiscussionRoomCacheModel model);
     
     /**
      * 여러 논의방 정보 일괄 조회 (전체조회시 사용)

--- a/src/main/java/org/example/civilbridge/domain/discussionRoom/infra/cache/DiscussionRoomCacheRepositoryImpl.java
+++ b/src/main/java/org/example/civilbridge/domain/discussionRoom/infra/cache/DiscussionRoomCacheRepositoryImpl.java
@@ -331,6 +331,41 @@ public class DiscussionRoomCacheRepositoryImpl implements DiscussionRoomCacheRep
         }
     }
     
+    // Redis에서만 단일 논의방 조회
+    @Override
+    public Optional<DiscussionRoomCacheModel> getCachedRoomOnly(Long roomId) {
+        try {
+            String roomKey = RedisKeyGenerator.generateRoomInfoKey(roomId);
+            Map<Object, Object> entries = redisTemplate.opsForHash().entries(roomKey);
+
+            if (entries.isEmpty()) {
+                log.debug("캐시 미스 - room:{}", roomId);
+                return Optional.empty();
+            }
+
+            DiscussionRoomCacheModel cached = DiscussionRoomCacheModel.fromRedisHash(entries);
+            log.debug("캐시 히트 - room:{}", roomId);
+            return Optional.ofNullable(cached);
+
+        } catch (Exception e) {
+            log.error("캐시 조회 실패 - room:{}, error: {}", roomId, e.getMessage(), e);
+            return Optional.empty();
+        }
+    }
+
+    // 논의방 정보를 Redis에만 캐싱 (room:{id} Hash)
+    @Override
+    public void cacheRoomInfo(DiscussionRoomCacheModel model) {
+        try {
+            String roomKey = RedisKeyGenerator.generateRoomInfoKey(model.getId());
+            redisTemplate.opsForHash().putAll(roomKey, model.toRedisHash());
+            redisTemplate.expire(roomKey, TTL_ROOM_INFO);
+            log.debug("논의방 정보 캐싱 완료 - room:{}", model.getId());
+        } catch (Exception e) {
+            log.error("논의방 정보 캐싱 실패 - room:{}, error: {}", model.getId(), e.getMessage(), e);
+        }
+    }
+
     // 여러 논의방 일괄 조회
     @Override
     public List<DiscussionRoomCacheModel> retrieveTotalCachingRoom(List<Long> roomIds) {

--- a/src/main/java/org/example/civilbridge/domain/discussionRoom/infra/persistence/member/MemberJpaRepository.java
+++ b/src/main/java/org/example/civilbridge/domain/discussionRoom/infra/persistence/member/MemberJpaRepository.java
@@ -1,5 +1,6 @@
 package org.example.civilbridge.domain.discussionRoom.infra.persistence.member;
 
+import org.example.civilbridge.domain.discussionRoom.infra.persistence.discussionRoom.DiscussionRoomEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -30,10 +31,10 @@ public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
     int countByRoomId(Long roomId);
 
     /**
-     * 사용자가 참여한 논의방 ID 목록 조회 (최신 참여순)
+     * 사용자가 참여한 논의방 목록 조회 (최신 참여순)
      */
-    @Query("SELECT m.roomId FROM MemberEntity m WHERE m.userId = :userId ORDER BY m.createdAt DESC")
-    Page<Long> findRoomIdsByUserIdOrderByJoinedAtDesc(Long userId, Pageable pageable);
+    @Query("SELECT dr FROM DiscussionRoomEntity dr, MemberEntity m WHERE dr.id = m.roomId AND m.userId = :userId ORDER BY m.createdAt DESC")
+    Page<DiscussionRoomEntity> findRoomsByUserIdOrderByJoinedAtDesc(@Param("userId") Long userId, Pageable pageable);
 
     /**
      * 여러 논의방의 멤버 수 일괄 조회 (N+1 쿼리 방지)

--- a/src/main/java/org/example/civilbridge/domain/discussionRoom/infra/persistence/member/MemberRepositoryImpl.java
+++ b/src/main/java/org/example/civilbridge/domain/discussionRoom/infra/persistence/member/MemberRepositoryImpl.java
@@ -1,8 +1,10 @@
 package org.example.civilbridge.domain.discussionRoom.infra.persistence.member;
 
 import lombok.RequiredArgsConstructor;
+import org.example.civilbridge.domain.discussionRoom.domain.model.DiscussionRoom;
 import org.example.civilbridge.domain.discussionRoom.domain.model.Member;
 import org.example.civilbridge.domain.discussionRoom.domain.repository.MemberRepository;
+import org.example.civilbridge.domain.discussionRoom.infra.persistence.discussionRoom.DiscussionRoomEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -46,8 +48,9 @@ public class MemberRepositoryImpl implements MemberRepository {
     }
 
     @Override
-    public Page<Long> findRoomIdsByUserId(Long userId, Pageable pageable) {
-        return memberJpaRepository.findRoomIdsByUserIdOrderByJoinedAtDesc(userId, pageable);
+    public Page<DiscussionRoom> findRoomsByUserId(Long userId, Pageable pageable) {
+        return memberJpaRepository.findRoomsByUserIdOrderByJoinedAtDesc(userId, pageable)
+                .map(DiscussionRoomEntity::toDomain);
     }
 
     @Override


### PR DESCRIPTION
…름 통일

- MemberRepository.findRoomIdsByUserId(Page<Long>) → findRoomsByUserId(Page<DiscussionRoom>)로 변경
  - MemberJpaRepository: theta join 쿼리로 DiscussionRoomEntity 직접 반환
  - MemberRepositoryImpl: .map(DiscussionRoomEntity::toDomain) 변환
- retrieveJoinedRooms에서 findAllByIdIn 추가 조회 제거
  - 이전: findRoomIdsByUserId(Page<Long>) → findAllByIdIn 2번 쿼리
  - 이후: findRoomsByUserId(Page<DiscussionRoom>) 1번 쿼리
- retrieveTotalRooms → retrieveRoomsByPage 메서드명 변경 (Controller 반영)
- getCachedRoomOnly, cacheRoomInfo 캐시 메서드 추가
  - 목록 조회 시 DB fallback 없이 Redis 조회만 수행 후 캐시 미스 시 직접 캐싱