### PR TITLE
feat(message): HTTP 채팅 메시지 전송 엔드포인트 추가

### DIFF
--- a/src/main/java/org/example/civilbridge/domain/message/api/MessageController.java
+++ b/src/main/java/org/example/civilbridge/domain/message/api/MessageController.java
@@ -1,10 +1,13 @@
 package org.example.civilbridge.domain.message.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.civilbridge.common.dto.ApiResponse;
+import org.example.civilbridge.common.jwt.CustomUserDetails;
 import org.example.civilbridge.domain.message.api.dto.MessagePageResponse;
 import org.example.civilbridge.domain.message.api.dto.MessageRequest;
 import org.example.civilbridge.domain.message.application.MessageService;
@@ -12,9 +15,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
@@ -38,6 +44,17 @@ public class MessageController {
     public void addUser(@Payload @Valid MessageRequest request, SimpMessageHeaderAccessor headerAccessor) {
         // 세션에 사용자 정보 저장
         messageService.processJoinMessage(request, headerAccessor);
+    }
+
+    @PostMapping("/api/messages/send")
+    @Operation(summary = "채팅 메시지 전송 (HTTP)", description = "HTTP 기반 채팅 메시지 전송 (부하테스트용)",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    public ResponseEntity<ApiResponse<Void>> sendMessageHttp(
+            @Valid @RequestBody MessageRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        messageService.processChatMessageForHttp(request, userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.success(null, "메시지가 전송되었습니다."));
     }
 
     @GetMapping("/api/messages/rooms/{roomId}")

--- a/src/main/java/org/example/civilbridge/domain/message/application/MessageService.java
+++ b/src/main/java/org/example/civilbridge/domain/message/application/MessageService.java
@@ -74,6 +74,27 @@ public class MessageService {
         }
     }
 
+    @Transactional
+    public void processChatMessageForHttp(MessageRequest request, Long userId) {
+        if (userId == null || !userId.equals(request.getUserId())) {
+            throw new BusinessException(MessageErrorCode.MESSAGE_USER_INCOINSISTENCY);
+        }
+        validateMessage(request);
+        validateMembership(request.getUserId(), request.getRoomId());
+
+        UserEntity userEntity = userJpaRepository.findById(request.getUserId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        DiscussionRoomEntity roomEntity = discussionRoomJpaRepository.findById(request.getRoomId())
+                .orElseThrow(() -> new BusinessException(DiscussionRoomErrorCode.ROOM_NOT_FOUND));
+
+        MessageEntity messageEntity = MessageEntity.builder()
+                .content(request.getContent())
+                .user(userEntity)
+                .discussionRoom(roomEntity)
+                .build();
+        messageRepository.save(messageEntity);
+    }
+
     public void processJoinMessage(MessageRequest request, SimpMessageHeaderAccessor headerAccessor) {
         // userId는 STOMP CONNECT 시점에 JWT로부터 StompChannelInterceptor가 세션에 저장
 


### PR DESCRIPTION
nGrinder 부하테스트를 위해 WebSocket 없이 동일한 DB 저장 로직을
수행하는 POST /api/messages/send 엔드포인트 추가.
Redis pub/sub 발행은 제외하고 DB 저장만 수행.