### PR TITLE
refactor(message): processChatMessageForHttp 멤버십 검증을 Redis ZSet 기반으로 전환

### DIFF
--- a/src/main/java/org/example/civilbridge/domain/message/application/MessageService.java
+++ b/src/main/java/org/example/civilbridge/domain/message/application/MessageService.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.civilbridge.common.exception.BusinessException;
 import org.example.civilbridge.common.exception.MessageException;
 import org.example.civilbridge.domain.discussionRoom.exception.DiscussionRoomErrorCode;
+import org.example.civilbridge.domain.discussionRoom.infra.cache.RedisKeyGenerator;
 import org.example.civilbridge.domain.discussionRoom.infra.persistence.discussionRoom.DiscussionRoomEntity;
 import org.example.civilbridge.domain.discussionRoom.infra.persistence.discussionRoom.DiscussionRoomJpaRepository;
 import org.example.civilbridge.domain.discussionRoom.infra.persistence.member.MemberJpaRepository;
@@ -21,6 +22,7 @@ import org.example.civilbridge.domain.user.exception.UserErrorCode;
 import org.example.civilbridge.domain.user.infra.persistence.UserEntity;
 import org.example.civilbridge.domain.user.infra.persistence.UserJpaRepository;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Service;
@@ -40,6 +42,7 @@ public class MessageService {
     private final DiscussionRoomJpaRepository discussionRoomJpaRepository;
     private final MessageRepository messageRepository;
     private final StringRedisTemplate stringRedisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
     private final MessageBatchWriter messageBatchWriter;
     private final ObjectMapper objectMapper;
 
@@ -83,7 +86,7 @@ public class MessageService {
 
     public void processChatMessageForHttp(MessageRequest request, Long userId) {
         validateMessage(request);
-        validateMembership(request.getUserId(), request.getRoomId());
+        validateMembershipFromCache(request.getUserId(), request.getRoomId());
 
         try {
             String json = objectMapper.writeValueAsString(Map.of(
@@ -147,6 +150,14 @@ public class MessageService {
 
     private void validateMembership(Long userId, Long roomId) {
         if (!memberJpaRepository.existsByUserIdAndRoomId(userId, roomId)) {
+            throw new MessageException(DiscussionRoomErrorCode.NOT_A_ROOM_MEMBER);
+        }
+    }
+
+    private void validateMembershipFromCache(Long userId, Long roomId) {
+        String key = RedisKeyGenerator.generateUserRoomsKey(userId);
+        Double score = redisTemplate.opsForZSet().score(key, roomId);
+        if (score == null) {
             throw new MessageException(DiscussionRoomErrorCode.NOT_A_ROOM_MEMBER);
         }
     }


### PR DESCRIPTION
- validateMembershipFromCache() 추가: user:{userId}:joined ZSet에서 ZSCORE로 참여 여부 확인
- processChatMessageForHttp()에서 DB 조회(validateMembership) 대신 캐시 검증(validateMembershipFromCache) 호출
- RedisTemplate<String, Object> 주입 추가 (GenericJackson2JsonRedisSerializer 직렬화 호환)
- 기존 validateMembership()은 WebSocket 경로(processChatMessage)에서 사용하므로 유지